### PR TITLE
Added pre_comment_user_ip filter

### DIFF
--- a/simple-comment-editing.php
+++ b/simple-comment-editing.php
@@ -1092,6 +1092,7 @@ class Simple_Comment_Editing {
 		} elseif ( isset( $_SERVER['REMOTE_ADDR'] ) ) {
 				$comment_author_ip = $_SERVER['REMOTE_ADDR'];
 		}
+		$comment_author_ip = apply_filters( 'pre_comment_user_ip', $comment_author_ip );
 		$comment_date_gmt = current_time( 'Y-m-d', 1 );
 		$user_agent       = substr( isset( $_SERVER['HTTP_USER_AGENT'] ) ? $_SERVER['HTTP_USER_AGENT'] : '', 0, 254 );
 		$hash             = md5( $comment_author_ip . $comment_date_gmt . $this->get_user_id() . $user_agent );


### PR DESCRIPTION
At line 1095. This applies the filter (normally to anonymize the commenters IP address) when generating the hash to compare later. The hash is later compared with a newly generated one which uses the IP stored in the DB - which will have been (possibly) modified by the filter (as called by WP itself). If we don't do the filter when first generating the hash, then there will be a mismatch later and the user will not be given the edit possibility.